### PR TITLE
Treat NSData like Data during initialization

### DIFF
--- a/HCJASON.podspec
+++ b/HCJASON.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "HCJASON"
-  s.version      = "4.0.3"
+  s.version      = "4.0.4"
   s.license      = { :type => "MIT" }
   s.homepage     = "https://github.com/housecanary/JASON"
   s.author       = { "Worth Baker" => "wbaker@housecanary.com" }

--- a/Source/JSON.swift
+++ b/Source/JSON.swift
@@ -43,14 +43,25 @@ public struct JSON {
     }
 
     /**
-        Creates an instance of JSON from NSData.
+        Creates an instance of JSON from Data.
 
-        - parameter data: An instance of NSData
+        - parameter data: An instance of Data
 
         - returns: the created JSON
     */
     public init(_ data: Data?) {
         self.init(object: JSON.objectWithData(data))
+    }
+
+    /**
+     Creates an instance of JSON from NSData.
+
+     - parameter data: An instance of NSData
+
+     - returns: the created JSON
+     */
+    public init(_ data: NSData?) {
+        self.init(data as Data?)
     }
     
     /**


### PR DESCRIPTION
In previous versions, NSData was treated as a general object
and not deserialized to a dictionary/array. For example:

```swift
let dict = ["foo": "bar", "alphabet": "abjanet"]
let data = try! JSONSerialization.data(withJSONObject: dict) as NSData

print("\(type(of: JSON(data).object!))") // NSConcreteData
print("\(JSON(data).dictionary)") // nil

print("\(type(of: JSON(data as Data).object!))") // __NSDictionaryI
print("\(JSON(data as Data).dictionary)") // ["foo": "bar", "alphabet": "abjanet"]
```

This commit adds an NSData-specific initializer that casts
NSData to Data and then deserializes the data.